### PR TITLE
Allowed for serial connections on Linux

### DIFF
--- a/java/src/Makelangelo/Makelangelo.java
+++ b/java/src/Makelangelo/Makelangelo.java
@@ -460,16 +460,22 @@ public class Makelangelo
 	
 	// find all available serial ports for the settings->ports menu.
 	public String[] ListSerialPorts() {
-		//System.out.print("OS NAME="+System.getProperty("os.name"));
-        if(System.getProperty("os.name").equals("Mac OS X")){
-        	portsDetected = SerialPortList.getPortNames("/dev/");
-            //System.out.println("OS X");
-        } else {
-        	portsDetected = SerialPortList.getPortNames("COM");
-            //System.out.println("Windows");
-        }
-        
-	    return portsDetected;
+		String OS = System.getProperty("os.name").toLowerCase();
+		
+	        if(OS.indexOf("mac") >= 0){
+	        	portsDetected = SerialPortList.getPortNames("/dev/");
+	            	//System.out.println("OS X");
+	        } else if(OS.indexOf("win") >= 0) {
+	        	portsDetected = SerialPortList.getPortNames("COM");
+	            	//System.out.println("Windows");
+	        } else if(OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") > 0){
+	        	portsDetected = SerialPortList.getPortNames("/dev/");
+	            	//System.out.println("Linux/Unix");
+	        } else {
+	        	System.out.println("OS ERROR");
+	        	System.out.println("OS NAME="+System.getProperty("os.name"));
+	        }
+		return portsDetected;
 	}
 	
 	// pull the last connected port from prefs


### PR DESCRIPTION
Removed default to Windows so that Linux is also usable. Allows for successful printing on Raspberry Pi among other systems. 
(Tested on Windows 8.1 and Raspbian)

Code referenced: http://www.mkyong.com/java/how-to-detect-os-in-java-systemgetpropertyosname/

![screenshot 11](https://cloud.githubusercontent.com/assets/7692426/6125357/0d9016e0-b0ca-11e4-8bc8-b84a0e9ec7e5.png)
