### PR TITLE
Made About HTML "Internationalizable"

### DIFF
--- a/java/languages/english.xml
+++ b/java/languages/english.xml
@@ -624,4 +624,46 @@
 		<value>Estimated time left: </value>
 		<hint>time machine will be drawing</hint>
 	</string>
+
+  <!-- Because the version string is declared in Java, AboutHTMLBeforeVersionNumber and AboutHTMLAfterVersionNumber are
+  used to dynamically build the HTML for the about message dialog using the version string. This is why there is not
+  one big CDATA html blob. -->
+  <string>
+    <key>AboutHTMLBeforeVersionNumber</key>
+    <value><![CDATA[
+    <html>
+      <body>
+        <h1>Makelangelo v
+    ]]>
+    </value>
+    <hint>HTML for About Dialog</hint>
+  </string>
+
+  <string>
+    <key>AboutHTMLAfterVersionNumber</key>
+    <value><![CDATA[
+</h1>
+      <h3>
+        <a href='http://www.marginallyclever.com/'>http://www.marginallyclever.com/</a>
+      </h3>
+        <p>
+          Created by Dan Royer (<a href="mailto:dan@marginallyclever.com">dan@marginallyclever.com</a>).<br>
+          Additional contributions by Joseph Cottam and <a href='https://github.com/virtuoushub'>Peter Colapietro<a/>.
+        </p>
+        <br>
+        <p>
+          To get the latest version please visit<br>
+          <a href='https://github.com/MarginallyClever/Makelangelo'>https://github.com/MarginallyClever/Makelangelo</a>
+        </p>
+        <br>
+        <p>
+          This program is open source and free.  As it should be!
+        </p>
+      </body>
+    </html>
+    ]]>
+    </value>
+    <hint>HTML for About Dialog</hint>
+  </string>
+
 </language>

--- a/java/languages/english.xml
+++ b/java/languages/english.xml
@@ -633,8 +633,7 @@
     <value><![CDATA[
     <html>
       <body>
-        <h1>Makelangelo v
-    ]]>
+        <h1>Makelangelo v]]>
     </value>
     <hint>HTML for About Dialog</hint>
   </string>

--- a/java/languages/espanol.xml
+++ b/java/languages/espanol.xml
@@ -471,4 +471,47 @@
 		<key>ZoomFit</key>
 		<value>Zoom to fit</value>
 	</string>
+  
+  <!-- FIXME Translate AboutHTMLBeforeVersionNumber and AboutHTMLAfterVersionNumber to Spanish.
+  Because the version string is declared in Java, AboutHTMLBeforeVersionNumber and AboutHTMLAfterVersionNumber are
+used to dynamically build the HTML for the about message dialog using the version string. This is why there is not
+one big CDATA html blob. -->
+  <string>
+    <key>AboutHTMLBeforeVersionNumber</key>
+    <value><![CDATA[
+    <html>
+      <body>
+        <h1>Makelangelo v
+    ]]>
+    </value>
+    <hint>HTML for About Dialog</hint>
+  </string>
+
+  <string>
+    <key>AboutHTMLAfterVersionNumber</key>
+    <value><![CDATA[
+</h1>
+      <h3>
+        <a href='http://www.marginallyclever.com/'>http://www.marginallyclever.com/</a>
+      </h3>
+        <p>
+          Created by Dan Royer (<a href="mailto:dan@marginallyclever.com">dan@marginallyclever.com</a>).<br>
+          Additional contributions by Joseph Cottam and <a href='https://github.com/virtuoushub'>Peter Colapietro<a/>.
+        </p>
+        <br>
+        <p>
+          To get the latest version please visit<br>
+          <a href='https://github.com/MarginallyClever/Makelangelo'>https://github.com/MarginallyClever/Makelangelo</a>
+        </p>
+        <br>
+        <p>
+          This program is open source and free.  As it should be!
+        </p>
+      </body>
+    </html>
+    ]]>
+    </value>
+    <hint>HTML for About Dialog</hint>
+  </string>
+
 </language>

--- a/java/languages/espanol.xml
+++ b/java/languages/espanol.xml
@@ -471,7 +471,7 @@
 		<key>ZoomFit</key>
 		<value>Zoom to fit</value>
 	</string>
-  
+
   <!-- FIXME Translate AboutHTMLBeforeVersionNumber and AboutHTMLAfterVersionNumber to Spanish.
   Because the version string is declared in Java, AboutHTMLBeforeVersionNumber and AboutHTMLAfterVersionNumber are
 used to dynamically build the HTML for the about message dialog using the version string. This is why there is not
@@ -481,8 +481,7 @@ one big CDATA html blob. -->
     <value><![CDATA[
     <html>
       <body>
-        <h1>Makelangelo v
-    ]]>
+        <h1>Makelangelo v]]>
     </value>
     <hint>HTML for About Dialog</hint>
   </string>

--- a/java/languages/french.xml
+++ b/java/languages/french.xml
@@ -612,4 +612,46 @@
 		<value>Partagez sur twitter avec @MarginallyC pour découvrir ce que les autres ont créé.</value>
 		<hint>Votre dessin est fini.  Share it</hint>
 	</string>
+
+  <!-- FIXME Translate AboutHTMLBeforeVersionNumber and AboutHTMLAfterVersionNumber to French.
+  Because the version string is declared in Java, AboutHTMLBeforeVersionNumber and AboutHTMLAfterVersionNumber are
+used to dynamically build the HTML for the about message dialog using the version string. This is why there is not
+one big CDATA html blob. -->
+  <string>
+    <key>AboutHTMLBeforeVersionNumber</key>
+    <value><![CDATA[
+    <html>
+      <body>
+        <h1>Makelangelo v
+    ]]>
+    </value>
+    <hint>HTML for About Dialog</hint>
+  </string>
+
+  <string>
+    <key>AboutHTMLAfterVersionNumber</key>
+    <value><![CDATA[
+</h1>
+      <h3>
+        <a href='http://www.marginallyclever.com/'>http://www.marginallyclever.com/</a>
+      </h3>
+        <p>
+          Created by Dan Royer (<a href="mailto:dan@marginallyclever.com">dan@marginallyclever.com</a>).<br>
+          Additional contributions by Joseph Cottam and <a href='https://github.com/virtuoushub'>Peter Colapietro<a/>.
+        </p>
+        <br>
+        <p>
+          To get the latest version please visit<br>
+          <a href='https://github.com/MarginallyClever/Makelangelo'>https://github.com/MarginallyClever/Makelangelo</a>
+        </p>
+        <br>
+        <p>
+          This program is open source and free.  As it should be!
+        </p>
+      </body>
+    </html>
+    ]]>
+    </value>
+    <hint>HTML for About Dialog</hint>
+  </string>
 </language>

--- a/java/languages/french.xml
+++ b/java/languages/french.xml
@@ -622,8 +622,7 @@ one big CDATA html blob. -->
     <value><![CDATA[
     <html>
       <body>
-        <h1>Makelangelo v
-    ]]>
+        <h1>Makelangelo v]]>
     </value>
     <hint>HTML for About Dialog</hint>
   </string>

--- a/java/languages/italiano.xml
+++ b/java/languages/italiano.xml
@@ -583,8 +583,7 @@ one big CDATA html blob. -->
     <value><![CDATA[
     <html>
       <body>
-        <h1>Makelangelo v
-    ]]>
+        <h1>Makelangelo v]]>
     </value>
     <hint>HTML for About Dialog</hint>
   </string>

--- a/java/languages/italiano.xml
+++ b/java/languages/italiano.xml
@@ -573,4 +573,46 @@
         <value>Tutti i valori sono in mm.</value>
 		<hint>Adjust machine size</hint>
     </string>
+
+  <!-- FIXME Translate AboutHTMLBeforeVersionNumber and AboutHTMLAfterVersionNumber to Italian.
+  Because the version string is declared in Java, AboutHTMLBeforeVersionNumber and AboutHTMLAfterVersionNumber are
+used to dynamically build the HTML for the about message dialog using the version string. This is why there is not
+one big CDATA html blob. -->
+  <string>
+    <key>AboutHTMLBeforeVersionNumber</key>
+    <value><![CDATA[
+    <html>
+      <body>
+        <h1>Makelangelo v
+    ]]>
+    </value>
+    <hint>HTML for About Dialog</hint>
+  </string>
+
+  <string>
+    <key>AboutHTMLAfterVersionNumber</key>
+    <value><![CDATA[
+</h1>
+      <h3>
+        <a href='http://www.marginallyclever.com/'>http://www.marginallyclever.com/</a>
+      </h3>
+        <p>
+          Created by Dan Royer (<a href="mailto:dan@marginallyclever.com">dan@marginallyclever.com</a>).<br>
+          Additional contributions by Joseph Cottam and <a href='https://github.com/virtuoushub'>Peter Colapietro<a/>.
+        </p>
+        <br>
+        <p>
+          To get the latest version please visit<br>
+          <a href='https://github.com/MarginallyClever/Makelangelo'>https://github.com/MarginallyClever/Makelangelo</a>
+        </p>
+        <br>
+        <p>
+          This program is open source and free.  As it should be!
+        </p>
+      </body>
+    </html>
+    ]]>
+    </value>
+    <hint>HTML for About Dialog</hint>
+  </string>
 </language>

--- a/java/src/Makelangelo/Makelangelo.java
+++ b/java/src/Makelangelo/Makelangelo.java
@@ -73,6 +73,7 @@ import Filters.*;
 // TODO image processing options - cutoff, exposure, resolution, voronoi stippling, edge tracing ?
 // TODO vector output ?
 // TODO externalize constants like version and ABOUT_HTML
+// TODO externalize constants like version
 
 public class Makelangelo
 		extends JPanel
@@ -83,16 +84,6 @@ public class Makelangelo
 
 	// software version
 	static final String version="7";
-	
-	// HTML for About Dialog.
-	private static final String ABOUT_HTML = "<html><body>"
-			+"<h1>Makelangelo v"+version+"</h1>"
-			+"<h3><a href='http://www.marginallyclever.com/'>http://www.marginallyclever.com/</a></h3>"
-            +"<p>Created by Dan Royer (<a href=\"mailto:dan@marginallyclever.com\">dan@marginallyclever.com</a>).<br>Additional contributions by Joseph Cottam and <a href='https://github.com/virtuoushub'>Peter Colapietro<a/>.</p><br>"
-			+"<p>To get the latest version please visit<br>"
-			+"<a href='https://github.com/MarginallyClever/Makelangelo'>https://github.com/MarginallyClever/Makelangelo</a></p><br>"
-			+"<p>This program is open source and free.  As it should be!</p>"
-			+"</body></html>";
 	
 	private static Makelangelo singletonObject;
 	
@@ -1590,7 +1581,19 @@ public class Makelangelo
 			return;
 		}
 		if( subject == buttonAbout ) {
-			final JTextComponent bottomText = createHyperlinkListenableJEditorPane(ABOUT_HTML);
+            final String aboutHtmlBeforeVersionNumber = MultilingualSupport.getSingleton().get("AboutHTMLBeforeVersionNumber");
+            final String aboutHmlAfterVersionNumber = MultilingualSupport.getSingleton().get("AboutHTMLAfterVersionNumber");
+            final int aboutHTMLBeforeVersionNumberLength = aboutHtmlBeforeVersionNumber.length();
+            final int versionNumberStringLength = version.length();
+            final int aboutHtmlAfterVersionNumberLength = aboutHmlAfterVersionNumber.length();
+            final int aboutHtmlStringBuilderCapacity = aboutHTMLBeforeVersionNumberLength + versionNumberStringLength + aboutHtmlAfterVersionNumberLength;
+            final StringBuilder aboutHtmlStringBuilder = new StringBuilder(aboutHtmlStringBuilderCapacity);
+            aboutHtmlStringBuilder.append(aboutHtmlBeforeVersionNumber);
+            aboutHtmlStringBuilder.append(version);
+            aboutHtmlStringBuilder.append(aboutHmlAfterVersionNumber);
+            final String aboutHtml = aboutHtmlStringBuilder.toString();
+
+			final JTextComponent bottomText = createHyperlinkListenableJEditorPane(aboutHtml);
 		    JOptionPane.showMessageDialog(null, bottomText);
 			return;
 		}

--- a/java/src/Makelangelo/Makelangelo.java
+++ b/java/src/Makelangelo/Makelangelo.java
@@ -1581,18 +1581,7 @@ public class Makelangelo
 			return;
 		}
 		if( subject == buttonAbout ) {
-            final String aboutHtmlBeforeVersionNumber = MultilingualSupport.getSingleton().get("AboutHTMLBeforeVersionNumber");
-            final String aboutHmlAfterVersionNumber = MultilingualSupport.getSingleton().get("AboutHTMLAfterVersionNumber");
-            final int aboutHTMLBeforeVersionNumberLength = aboutHtmlBeforeVersionNumber.length();
-            final int versionNumberStringLength = version.length();
-            final int aboutHtmlAfterVersionNumberLength = aboutHmlAfterVersionNumber.length();
-            final int aboutHtmlStringBuilderCapacity = aboutHTMLBeforeVersionNumberLength + versionNumberStringLength + aboutHtmlAfterVersionNumberLength;
-            final StringBuilder aboutHtmlStringBuilder = new StringBuilder(aboutHtmlStringBuilderCapacity);
-            aboutHtmlStringBuilder.append(aboutHtmlBeforeVersionNumber);
-            aboutHtmlStringBuilder.append(version);
-            aboutHtmlStringBuilder.append(aboutHmlAfterVersionNumber);
-            final String aboutHtml = aboutHtmlStringBuilder.toString();
-
+            final String aboutHtml = getAboutHtmlFromMultilingualString();
 			final JTextComponent bottomText = createHyperlinkListenableJEditorPane(aboutHtml);
 		    JOptionPane.showMessageDialog(null, bottomText);
 			return;
@@ -1634,6 +1623,24 @@ public class Makelangelo
 	}
 
 	/**
+	 * 
+     * @return An HTML string (supports internationalization) used for the About Message Dialog.
+     */
+    private String getAboutHtmlFromMultilingualString() {
+        final String aboutHtmlBeforeVersionNumber = MultilingualSupport.getSingleton().get("AboutHTMLBeforeVersionNumber");
+        final String aboutHmlAfterVersionNumber = MultilingualSupport.getSingleton().get("AboutHTMLAfterVersionNumber");
+        final int aboutHTMLBeforeVersionNumberLength = aboutHtmlBeforeVersionNumber.length();
+        final int versionNumberStringLength = version.length();
+        final int aboutHtmlAfterVersionNumberLength = aboutHmlAfterVersionNumber.length();
+        final int aboutHtmlStringBuilderCapacity = aboutHTMLBeforeVersionNumberLength + versionNumberStringLength + aboutHtmlAfterVersionNumberLength;
+        final StringBuilder aboutHtmlStringBuilder = new StringBuilder(aboutHtmlStringBuilderCapacity);
+        aboutHtmlStringBuilder.append(aboutHtmlBeforeVersionNumber);
+        aboutHtmlStringBuilder.append(version);
+        aboutHtmlStringBuilder.append(aboutHmlAfterVersionNumber);
+        return aboutHtmlStringBuilder.toString();
+    }
+
+    /**
 	 * 
 	 * @param html String of valid HTML.
 	 * @return a 

--- a/java/src/Makelangelo/Makelangelo.java
+++ b/java/src/Makelangelo/Makelangelo.java
@@ -82,8 +82,10 @@ public class Makelangelo
 	// Java required?
 	static final long serialVersionUID=1L;
 
-	// software version
-	static final String version="7";
+    /**
+     * software version
+     */
+	public static final String version="7";
 	
 	private static Makelangelo singletonObject;
 	
@@ -1624,7 +1626,18 @@ public class Makelangelo
 
 	/**
 	 * 
-     * @return An HTML string (supports internationalization) used for the About Message Dialog.
+     * <p>
+     * Uses {@link java.lang.StringBuilder#append(String)} to create an internationalization supported {@code String}
+     * representing the About Message Dialog's HTML.
+     * </p>
+     *
+     * <p>
+     * The summation of {@link String#length()} for each of the respective values retrieved with the
+     * {@code "AboutHTMLBeforeVersionNumber"}, and {@code "AboutHTMLAfterVersionNumber"} {@link MultilingualSupport} keys,
+     * in conjunction with {@link Makelangelo#version} is calculated for use with {@link java.lang.StringBuilder#StringBuilder(int)}.
+     * </p>
+     *
+     * @return An HTML string used for the About Message Dialog.
      */
     private String getAboutHtmlFromMultilingualString() {
         final String aboutHtmlBeforeVersionNumber = MultilingualSupport.getSingleton().get("AboutHTMLBeforeVersionNumber");


### PR DESCRIPTION
After reading @i-make-robots' [comment](https://github.com/MarginallyClever/Makelangelo/pull/61#issuecomment-85517620), I pulled out the hardcoded About Message Dialog's HTML String constant into the translation file.

Because of the dynamic way the HTML is built in the Java code, I had to split the internationalized HTML String in two. I added the key/values to the all the languages, FIXMEs where it is not translated, and documentation as to why the key/values are split up in the Java and XML files.