### PR TITLE
Added manifest entry for splash screen.

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -24,6 +24,10 @@
           <version>2.5.3</version>
         <configuration>
           <archive>
+            <manifestEntries>
+              <!-- FIXME replace logo.png with high quality splash image. -->
+              <SplashScreen-Image>logo.png</SplashScreen-Image>
+            </manifestEntries>
             <manifest>
               <mainClass>com.marginallyclever.makelangelo.Makelangelo</mainClass>
             </manifest>
@@ -63,6 +67,10 @@
         <version>2.6</version>
         <configuration>
           <archive>
+            <manifestEntries>
+              <!-- FIXME replace logo.png with high quality splash image. -->
+              <SplashScreen-Image>logo.png</SplashScreen-Image>
+            </manifestEntries>
             <manifest>
               <mainClass>com.marginallyclever.makelangelo.Makelangelo</mainClass>
             </manifest>


### PR DESCRIPTION
Closes #75

This will not be apparent when launching from an IDE

Developers must configure their IDE to use the "-splash:src/main/resources/logo.png" VM option.

# Eclipse Example
![Eclipse Example](https://cloud.githubusercontent.com/assets/4303638/7311258/ee660a14-ea07-11e4-8f96-be1a845226e0.png)
