### PR TITLE
Feature/preference refactor patch

### DIFF
--- a/java/src/main/java/com/marginallyclever/makelangelo/PreferencesHelper.java
+++ b/java/src/main/java/com/marginallyclever/makelangelo/PreferencesHelper.java
@@ -24,8 +24,8 @@ public final class PreferencesHelper {
     static {
         final Map<MakelangeloPreferenceKey, Preferences> initialMap = new HashMap<>();
         final Preferences userRootPreferencesNode = Preferences.userRoot();
-        final String thisPackageName = PreferencesHelper.class.getPackage().getName();
-        final Preferences makelangeloPreferenceNode = userRootPreferencesNode.node(thisPackageName);
+        //final String thisPackageName = PreferencesHelper.class.getPackage().getName();
+        final Preferences makelangeloPreferenceNode = userRootPreferencesNode.node("DrawBot");// thisPackageName); FIXME write unit test/tool to view import/export machine configurations.
         initialMap.put(MakelangeloPreferenceKey.MAKELANGELO_ROOT, makelangeloPreferenceNode);
         initialMap.put(MakelangeloPreferenceKey.GRAPHICS, makelangeloPreferenceNode.node("Graphics"));
         initialMap.put(MakelangeloPreferenceKey.MACHINES, makelangeloPreferenceNode.node("Machines"));


### PR DESCRIPTION
After my [preferences refactor](https://github.com/MarginallyClever/Makelangelo/pull/95), old [Machine Configuration preferences are in limbo](https://github.com/MarginallyClever/Makelangelo/issues/105#issuecomment-105768290). This is my attempt to bring them back.