### PR TITLE
Add an assembly descriptor that produces a onejar

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -127,11 +127,10 @@ If you like this project, please support us by buying Marginally Clever products
               <mainClass>com.marginallyclever.makelangelo.Makelangelo</mainClass>
             </manifest>
           </archive>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
+          <descriptors>
+            <descriptor>src/main/assembly/application.xml</descriptor>
+          </descriptors>
         </configuration>
-        <!-- see http://stackoverflow.com/a/574650 -->
         <executions>
           <execution>
             <id>make-assembly</id>
@@ -266,19 +265,12 @@ If you like this project, please support us by buying Marginally Clever products
     </dependency>
     <dependency>
       <groupId>org.jogamp.gluegen</groupId>
-        <artifactId>gluegen-rt-main</artifactId>
-        <version>${jogl.version}</version>
-        <scope>runtime</scope>
+      <artifactId>gluegen-rt-main</artifactId>
+      <version>${jogl.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jogamp.jogl</groupId>
-        <artifactId>jogl-all-main</artifactId>
-        <version>${jogl.version}</version>
-        <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jogamp.jogl</groupId>
-      <artifactId>jogl-all</artifactId>
+      <artifactId>jogl-all-main</artifactId>
       <version>${jogl.version}</version>
     </dependency>
     <dependency>

--- a/java/src/main/assembly/application.xml
+++ b/java/src/main/assembly/application.xml
@@ -1,0 +1,104 @@
+<assembly
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+
+  <id>with-dependencies</id>
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <formats>
+    <format>jar</format>
+  </formats>
+
+  <dependencySets>
+    <!-- Unpack everything that isn't a JOGL or GlueGen library -->
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <scope>runtime</scope>
+      <unpack>true</unpack>
+      <unpackOptions>
+        <excludes>
+          <exclude>libgluegen-rt*</exclude>
+          <exclude>libjogl_desktop.*</exclude>
+          <exclude>libjogl_mobile.*</exclude>
+          <exclude>libnativewindow_awt.*</exclude>
+          <exclude>libnativewindow_macosx.*</exclude>
+          <exclude>libnativewindow_x11.*</exclude>
+          <exclude>libnewt.*</exclude>
+        </excludes>
+      </unpackOptions>
+    </dependencySet>
+
+    <dependencySet>
+      <outputDirectory>/natives/linux-amd64/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <scope>runtime</scope>
+      <unpack>true</unpack>
+      <includes>
+        <include>org.jogamp.gluegen:gluegen-rt:jar:natives-linux-amd64</include>
+        <include>org.jogamp.jogl:jogl-all:jar:natives-linux-amd64</include>
+      </includes>
+      <unpackOptions>
+        <includes><include>*.so</include></includes>
+      </unpackOptions>
+    </dependencySet>
+
+    <dependencySet>
+      <outputDirectory>/natives/linux-i586/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <scope>runtime</scope>
+      <unpack>true</unpack>
+      <includes>
+        <include>org.jogamp.gluegen:gluegen-rt:jar:natives-linux-i586</include>
+        <include>org.jogamp.jogl:jogl-all:jar:natives-linux-i586</include>
+      </includes>
+      <unpackOptions>
+        <includes><include>*.so</include></includes>
+      </unpackOptions>
+    </dependencySet>
+
+    <dependencySet>
+      <outputDirectory>/natives/windows-amd64/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <scope>runtime</scope>
+      <unpack>true</unpack>
+      <includes>
+        <include>org.jogamp.gluegen:gluegen-rt:jar:natives-windows-amd64</include>
+        <include>org.jogamp.jogl:jogl-all:jar:natives-windows-amd64</include>
+      </includes>
+      <unpackOptions>
+        <includes><include>*.dll</include></includes>
+      </unpackOptions>
+    </dependencySet>
+
+    <dependencySet>
+      <outputDirectory>/natives/windows-i586/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <scope>runtime</scope>
+      <unpack>true</unpack>
+      <includes>
+        <include>org.jogamp.gluegen:gluegen-rt:jar:natives-windows-i586</include>
+        <include>org.jogamp.jogl:jogl-all:jar:natives-windows-i586</include>
+      </includes>
+      <unpackOptions>
+        <includes><include>*.dll</include></includes>
+      </unpackOptions>
+    </dependencySet>
+
+    <dependencySet>
+      <outputDirectory>/natives/macosx-universal/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <scope>runtime</scope>
+      <unpack>true</unpack>
+      <includes>
+        <include>org.jogamp.gluegen:gluegen-rt:jar:natives-macosx-universal</include>
+        <include>org.jogamp.jogl:jogl-all:jar:natives-macosx-universal</include>
+      </includes>
+      <unpackOptions>
+        <includes><include>*.jnilib</include></includes>
+      </unpackOptions>
+    </dependencySet>
+  </dependencySets>
+
+</assembly>


### PR DESCRIPTION
This replaces the use of the Maven Assembly plugin's
"jar-with-dependencies" descriptor with a custom descriptor
that places the required native libraries for Windows AMD64/i586,
Linux AMD64/i586, and OS X Universal into the correct place in
the resulting jar file.

See https://jogamp.org/bugzilla/show_bug.cgi?id=845 for details.