### PR TITLE
Update to JogAmp JOGL 2.3.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -192,7 +192,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <minimum.maven.version>2.2.1</minimum.maven.version>
     <minimum.java.version>1.7</minimum.java.version>
-    <jogl.version>2.3.1</jogl.version>
+    <jogl.version>2.3.2</jogl.version>
     <maven-dependency-plugin.ignoreNonCompile>true</maven-dependency-plugin.ignoreNonCompile>
   </properties>
 


### PR DESCRIPTION
JogAmp 2.3.2 is the first version that support maven one-jar deployment.
https://github.com/xranby/Makelangelo/releases/tag/v7.1.3